### PR TITLE
Add binutils to base system image

### DIFF
--- a/src-sh/void-install-zfs.sh
+++ b/src-sh/void-install-zfs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-SERVER_PACKAGES="zsh fish-shell firejail openvpn neofetch sl wget trident-core"
+SERVER_PACKAGES="zsh fish-shell firejail openvpn neofetch sl wget trident-core binutils"
 LITE_PACKAGES="${SERVER_PACKAGES} wpa-cute ntfs-3g fuse-exfat simple-mtpfs trident-desktop setxkbmap"
 FULL_PACKAGES="${LITE_PACKAGES} telegram-desktop vlc firefox trojita pianobar libreoffice cups foomatic-db foomatic-db-engine cups-filters"
 


### PR DESCRIPTION
binutils is a base gnu userland toolset normally its included with coreutils as a dependency, but I guess with void its not. It has the both `ld` linkers, as well as `ar`, `strings`, `objdump`, etc. It's only 3mb, and of such a base level that we should probably include it.  When all else fails